### PR TITLE
Fix agent imports and calls in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,10 +6,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 # <<< KLUCZOWE: importy zgodne z Twoim układem katalogów >>>
-import autoagent.agents.operations_agent as operations_agent
-import autoagent.agents.staff_directory_agent as staff_directory_agent
-import autoagent.agents.camera_agent as camera_agent
-import autoagent.agents.doors_agent as doors_agent
+from autoagent.agents.operations_agent import operations_agent as operations_fn
+from autoagent.agents.staff_directory_agent import staff_directory_agent as staff_fn
+from autoagent.agents.camera_agent import camera_agent as camera_fn
+from autoagent.agents.doors_agent import doors_agent as doors_fn
 # <<< ---------------------------------------------------- >>>
 
 FRONTEND_ORIGIN = os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")
@@ -40,20 +40,20 @@ def health():
 
 @app.get("/api/ask", response_model=AgentResponse)
 def api_ask(q: str = Query(...), refresh: Optional[int] = 0):
-    res = operations_agent.operations_agent(q, context=_ctx(bool(refresh)))
+    res = operations_fn(q, context=_ctx(bool(refresh)))
     return AgentResponse(agent="operations_agent", query=q, result=res)
 
 @app.get("/api/staff", response_model=AgentResponse)
 def api_staff(q: str = Query(...), refresh: Optional[int] = 0):
-    res = staff_directory_agent.staff_directory_agent(q, context=_ctx(bool(refresh)))
+    res = staff_fn(q, context=_ctx(bool(refresh)))
     return AgentResponse(agent="staff_directory_agent", query=q, result=res)
 
 @app.get("/api/cameras", response_model=AgentResponse)
 def api_cameras(q: str = Query(...), refresh: Optional[int] = 0):
-    res = camera_agent.camera_agent(q, context=_ctx(bool(refresh)))
+    res = camera_fn(q, context=_ctx(bool(refresh)))
     return AgentResponse(agent="camera_agent", query=q, result=res)
 
 @app.get("/api/doors", response_model=AgentResponse)
 def api_doors(q: str = Query(...), refresh: Optional[int] = 0):
-    res = doors_agent.doors_agent(q, context=_ctx(bool(refresh)))
+    res = doors_fn(q, context=_ctx(bool(refresh)))
     return AgentResponse(agent="doors_agent", query=q, result=res)


### PR DESCRIPTION
## Summary
- switch FastAPI agent imports to direct function aliases to prevent attribute errors
- update each API endpoint to call the imported agent functions directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcf737e7c8330a21217d2e4734d2c